### PR TITLE
Fix CI workflow artifact upload warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test
+      - name: Run tests with coverage
+        run: npm run test:coverage
 
       - name: Upload test results
         if: always()
@@ -75,6 +75,7 @@ jobs:
           name: test-results-node-${{ matrix.node-version }}
           path: coverage/
           retention-days: 30
+          if-no-files-found: warn
 
   build:
     runs-on: ubuntu-latest
@@ -100,6 +101,7 @@ jobs:
           name: build-artifacts
           path: .next/
           retention-days: 7
+          if-no-files-found: warn
 
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes
- Change test command from `npm test` to `npm run test:coverage` to generate coverage reports
- Add `if-no-files-found: warn` to artifact uploads to prevent error annotations

## Fixes
- Resolves 'No files were found with the provided path: coverage/' warnings
- Resolves 'No files were found with the provided path: .next/' warnings

## Testing
- CI workflow will now generate coverage reports properly
- Artifact uploads will show warnings instead of errors when files are missing