### PR TITLE
fix: temporarily disable GPG signing for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,4 +20,3 @@ jobs:
         env:
           LOG_LEVEL: "info"
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.RENOVATE_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
Temporarily disable GPG signing for Renovate to resolve the package-lock.json issue. This allows Renovate to work without signed commits until we can properly configure GPG signing for the bot user.